### PR TITLE
Fixed menu opening bug and empty array bug

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -11,7 +11,7 @@ html {
 
 
 #toggle {
-  width: 0;
+  width: 0px;
   height: 100%;
   top: 0;
   left: 0;

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -79,7 +79,6 @@
 
             const showEvents = () => {
                 fetchEventData()
-                console.log(document.getElementById("toggle").style.width)
                 if (document.getElementById("toggle").style.width == "0px" || document.getElementById("toggle").style.width == "") {
                     document.getElementById("toggle").style.width = "250px";
                 } else {

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -44,7 +44,6 @@
                 fetch(`events`, myInit)
                 .then((data) => data.json())
                 .then((data) => {
-                    console.log(data)
                     events = []
                     for (let event in data["data"]) {
                         curr = data["data"][event]
@@ -69,8 +68,7 @@
                             `
                         )
                     }
-
-                    if (events == []) {
+                    if (events.length == 0) {
                         document.getElementById("eventList").innerHTML = "No events are running at the moment."
                     } else {
                         document.getElementById("eventList").innerHTML = events.reverse().join('')
@@ -81,7 +79,8 @@
 
             const showEvents = () => {
                 fetchEventData()
-                if (document.getElementById("toggle").style.width == "0px") {
+                console.log(document.getElementById("toggle").style.width)
+                if (document.getElementById("toggle").style.width == "0px" || document.getElementById("toggle").style.width == "") {
                     document.getElementById("toggle").style.width = "250px";
                 } else {
                     document.getElementById("toggle").style.width = "0px";


### PR DESCRIPTION
Two bugs are fixed: 
1) If the events sidebar is opened for the first time, the width property is "" and not "0px" and hence the button has to be pressed again for the events sidebar to open. 
2) If the events endpoint is empty, the sidebar now correctly shows that there are no events running at the moment. 